### PR TITLE
Add basic Go implementation for benchmark reference

### DIFF
--- a/basic/gobasic_test.go
+++ b/basic/gobasic_test.go
@@ -1,0 +1,144 @@
+package basic
+
+import (
+	"sort"
+	"testing"
+)
+
+type goBasic struct{}
+
+func (fk goBasic) Reduce(numbers []int, f func(acc, elem int) int, acc int) int {
+	for _, v := range numbers {
+		acc = f(acc, v)
+	}
+	return acc
+}
+func (fk goBasic) Map(numbers []int, f func(val int) int) []int {
+	result := make([]int, len(numbers))
+	for i, v := range numbers {
+		result[i] = f(v)
+	}
+	return result
+}
+
+func (fk goBasic) Reverse(numbers []int) []int {
+	result := make([]int, len(numbers))
+	for i, v := range numbers {
+		result[len(numbers)-1-i] = v
+	}
+	return result
+}
+func (fk goBasic) Filter(numbers []int, f func(val int) bool) []int {
+	result := make([]int, 0, len(numbers))
+	for _, v := range numbers {
+		if f(v) {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+func (fk goBasic) Sort(numbers []int, f func(i, j int) int) []int {
+	result := append(make([]int, 0, len(numbers)), numbers...)
+	sort.Sort(byFunc{Slice: result, Func: f})
+	return result
+}
+func (fk goBasic) Contains(numbers []int, needle int) bool {
+	for _, v := range numbers {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
+var basic goBasic
+
+func BenchmarkGoBasicSumElements5000(b *testing.B) {
+	var result int
+	for i := 0; i < b.N; i++ {
+		result = int(basic.Reduce(numbers5000, sum, 0))
+	}
+	var expected = 0
+	for _, val := range numbers5000 {
+		expected += val
+	}
+	if expected != result {
+		b.FailNow()
+	}
+}
+
+func BenchmarkGoBasicDuplElements5000(b *testing.B) {
+	var result []int
+	for i := 0; i < b.N; i++ {
+		result = basic.Map(numbers5000, func(val int) int {
+			return val * 2
+		})
+	}
+	for index := range numbers5000 {
+		if numbers5000[index]*2 != result[index] {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkGoBasicReverseElements5000(b *testing.B) {
+	var result []int
+	for i := 0; i < b.N; i++ {
+		result = basic.Reverse(numbers5000)
+	}
+	for index := range numbers5000 {
+		if numbers5000[index] != result[4999-index] {
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkGoBasicFilterElements5000(b *testing.B) {
+	var result []int
+	for i := 0; i < b.N; i++ {
+		result = basic.Filter(numbers5000, func(val int) bool {
+			return val%2 == 0
+		})
+	}
+	for _, val := range result {
+		if val%2 != 0 {
+			b.FailNow()
+		}
+	}
+}
+func BenchmarkGoBasicSortElements5000(b *testing.B) {
+	var result []int
+	for i := 0; i < b.N; i++ {
+		result = basic.Sort(numbers5000, func(i, j int) int {
+			if i <= j {
+				return -1
+			}
+			return 1
+		})
+	}
+	for index := 0; index < 4999; index++ {
+		if result[index] > result[index+1] {
+			b.Logf("[%d]=%d > %d=[%d]", index, result[index], result[index+1], index+1)
+			b.FailNow()
+		}
+	}
+}
+
+func BenchmarkGoBasicContainsElements5000(b *testing.B) {
+	var result bool
+	for i := 0; i < b.N; i++ {
+		result = basic.Contains(numbers5000, numbers5000[4999])
+	}
+	if !result {
+		b.FailNow()
+	}
+}
+
+type byFunc struct {
+	Slice []int
+	Func  func(i, j int) int
+}
+
+func (by byFunc) Len() int           { return len(by.Slice) }
+func (by byFunc) Swap(i, j int)      { by.Slice[i], by.Slice[j] = by.Slice[j], by.Slice[i] }
+func (by byFunc) Less(i, j int) bool { return by.Func(by.Slice[i], by.Slice[j]) < 0 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wesovilabs/koazee-comparison
 require (
 	github.com/ahmetb/go-linq v3.0.0+incompatible
 	github.com/thoas/go-funk v0.0.0-20181020164546-fbae87fb5b5c
-	github.com/wesovilabs/koazee v0.0.0
+	github.com/wesovilabs/koazee v0.0.2
 )
 
 replace github.com/wesovilabs/koazee => ../koazee

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/thoas/go-funk v0.0.0-20181020164546-fbae87fb5b5c h1:3sFKuGerP3mGyXo7gDR1dGQ6GdIrI8s5KWmct0R5J6A=
 github.com/thoas/go-funk v0.0.0-20181020164546-fbae87fb5b5c/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=
+github.com/wesovilabs/koazee v0.0.2 h1:4+MNj8MJc6DM1DDG8zhoxTsHMaM56eWHfSB86ghc+j8=
+github.com/wesovilabs/koazee v0.0.2/go.mod h1:ENb08mzjzlcADZmHgUCDuL394ExYr+VZX43hqnGgqDU=
 golang.org/x/crypto v0.0.0-20180505025534-4ec37c66abab/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
```
$ go test -run=- -bench=.
goos: linux
goarch: amd64
pkg: github.com/wesovilabs/koazee-comparison/basic
BenchmarkGoBasicSumElements5000-4                 100000             15740 ns/op
BenchmarkGoBasicDuplElements5000-4                 50000             24527 ns/op
BenchmarkGoBasicReverseElements5000-4             100000             10883 ns/op
BenchmarkGoBasicFilterElements5000-4               30000             56522 ns/op
BenchmarkGoBasicSortElements5000-4                  2000           1282834 ns/op
BenchmarkGoBasicContainsElements5000-4          10000000               218 ns/op
BenchmarkGoFunkSumElements5000-4                    1000           2352172 ns/op
BenchmarkGoFunkDuplElements5000-4                   1000           2339016 ns/op
BenchmarkGoFunkReverseElements5000-4               10000            177185 ns/op
BenchmarkGoFunkFilterElements5000-4                 1000           1950437 ns/op
BenchmarkGoFunkContainsElements5000-4              20000             65498 ns/op
BenchmarkGoLinqSumElements5000-4                    5000            249645 ns/op
BenchmarkGoLinqDuplElements5000-4                   3000            510294 ns/op
BenchmarkGoLinqReverseElements5000-4                2000            543050 ns/op
BenchmarkGoLinqSortElements5000-4                   1000           2020100 ns/op
BenchmarkGoLinqFilterElements5000-4                 5000            344080 ns/op
BenchmarkGoLinqContainsElements5000-4              50000             26978 ns/op
BenchmarkGoLinqOperationgWithStrings50008b-4         500           2852205 ns/op
BenchmarkKoazeeSumElements5000-4                  100000             16634 ns/op
BenchmarkKoazeeDuplElements5000-4                  50000             25104 ns/op
BenchmarkKoazeeReverseElements5000-4              100000             12431 ns/op
BenchmarkKoazeeSortElements5000-4                   3000            393634 ns/op
BenchmarkKoazeeFilterElements5000-4                20000             64534 ns/op
BenchmarkKoazeeContainsElements5000-4             500000              3755 ns/op
```

BTW congratulations, Koazee is not much slower than a basic Go for cycle!